### PR TITLE
Enable netrw (#394)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,8 +1,8 @@
-require('plugins')
 require('lv-globals')
+require('settings')
+require('plugins')
 require('lv-utils')
 require('lv-autocommands')
-require('settings')
 vim.cmd('luafile ~/.config/nvim/lv-settings.lua')
 require('keymappings')
 require('lv-nvimtree') -- This plugin must be required somewhere before colorscheme.  Placing it after will break navigation keymappings

--- a/lua/lv-globals.lua
+++ b/lua/lv-globals.lua
@@ -8,6 +8,7 @@ O = {
     relative_number = true,
     shell = 'bash',
 	timeoutlen = 100,
+    nvim_tree_disable_netrw = 0, -- "1 by default, disables netrw (must be set before plugin's packadd)
 
     -- @usage pass a table with your desired languages
     treesitter = {

--- a/lua/lv-nvimtree/init.lua
+++ b/lua/lv-nvimtree/init.lua
@@ -13,7 +13,7 @@ let g:nvim_tree_show_icons = {
 "If 0, do not show the icons for one of 'git' 'folder' and 'files'
 "1 by default, notice that if 'files' is 1, it will only display
 "if nvim-web-devicons is installed and on your runtimepath ]] -- vim.g.nvim_tree_ignore = [ '.git', 'node_modules', '.cache' ] "empty by default
-vim.g.nvim_tree_disable_netrw = 0 -- "1 by default, disables netrw
+-- vim.g.nvim_tree_disable_netrw = 0 -- moved to lv-globals
 -- vim.g.nvim_tree_hijack_netrw = 0 --"1 by default, prevents netrw from automatically opening when opening directories (but lets you keep its other utilities)
 vim.g.nvim_tree_hide_dotfiles = 1 -- 0 by default, this option hides files and folders starting with a dot `.`
 vim.g.nvim_tree_indent_markers = 1 -- "0 by default, this option shows indent markers when folders are open

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -34,6 +34,7 @@ vim.wo.signcolumn = "yes" -- Always show the signcolumn, otherwise it would shif
 vim.o.updatetime = 300 -- Faster completion
 vim.o.timeoutlen = O.timeoutlen -- By default timeoutlen is 1000 ms
 vim.o.clipboard = "unnamedplus" -- Copy paste between vim and everything else
+vim.g.nvim_tree_disable_netrw = O.nvim_tree_disable_netrw
 -- vim.o.guifont = "JetBrainsMono\\ Nerd\\ Font\\ Mono:h18"
 -- vim.o.guifont = "Hack\\ Nerd\\ Font\\ Mono"
 -- vim.o.guifont = "SauceCodePro Nerd Font:h17"


### PR DESCRIPTION
* enable_netrw: source lv-globals before plugins and add nvim_tree_disable_netrw to lv-globals, otherwise netrw is never enabled.
If netrw is not enabled, netrw-externapp functionality, things like gx and gf to follow http links do not work.

* enable_netrw: add nvim_tree_disable_netrw to the lv-globals O object and set it in settings && source settings before plugins